### PR TITLE
Add support for RQ 0.6.0

### DIFF
--- a/src/pyramid_rq/worker.py
+++ b/src/pyramid_rq/worker.py
@@ -16,11 +16,11 @@ class PyramidWorker(Worker):
         super(PyramidWorker, self).__init__(*a, **kw)
         self.environment = environment
 
-    def perform_job(self, job):
+    def perform_job(self, job, queue='default'):
         self.procline('Initializing pyramid for %s from %s' % 
                 (job.func_name, job.origin))
         try:
-            super(PyramidWorker, self).perform_job(job)
+            super(PyramidWorker, self).perform_job(job, queue)
             if HAVE_TRANSACTION:
                 get_transaction.commit()
         except:


### PR DESCRIPTION
Hello,

According to rq version 0.6.0 perform_job function in Worker class expects also queue param (so self, worker and queue). Please see reference code: https://github.com/nvie/rq/blob/master/rq/worker.py:

This pull request reflects that change.
